### PR TITLE
Improves velocity handling in contexts and states

### DIFF
--- a/ufedmm/integrators.py
+++ b/ufedmm/integrators.py
@@ -213,7 +213,7 @@ class CustomIntegrator(openmm.CustomIntegrator):
         )
         temperatures = [system_temperature] * nparticles + extended_space_temperatures
         kT = [
-            unit.MOLAR_GAS_CONSTANT_R * T * openmm.Vec3(1, 1, 1) for T in temperatures
+            unit.MOLAR_GAS_CONSTANT_R * T * openmm.Vec3(1, 0, 0) for T in temperatures
         ]
         self.setPerDofVariableByName("kT", kT)
         self._up_to_date = True

--- a/ufedmm/ufedmm.py
+++ b/ufedmm/ufedmm.py
@@ -1030,21 +1030,35 @@ class ExtendedSpaceContext(openmm.Context):
             randomSeed : int, default=None
                 A seed for the random number generator.
         """
+        temperature = _standardized(temperature)
         system = self.getSystem()
         Ntotal = system.getNumParticles()
         Natoms = Ntotal - len(self.variables)
-        m = np.array([system.getParticleMass(i) / unit.dalton for i in range(Ntotal)])
-        T = np.array(
-            [_standardized(temperature)] * Natoms
-            + [v.temperature for v in self.variables]
+        masses = np.array(
+            [system.getParticleMass(i) / unit.dalton for i in range(Ntotal)]
         )
-        sigma = np.sqrt(_standardized(unit.MOLAR_GAS_CONSTANT_R) * T / m)
+        temperatures = np.array(
+            [temperature] * Natoms + [v.temperature for v in self.variables]
+        )
+        kboltz = _standardized(unit.MOLAR_GAS_CONSTANT_R)
+        sigmas = np.sqrt(kboltz * temperatures / masses)[:, None]
         random = np.random.RandomState(randomSeed)
-        velocities = sigma[:, None] * random.normal(0, 1, (Ntotal, 3))
-        vcm = np.sum(m[:Natoms, None] * velocities[:Natoms], axis=0) / m[:Natoms].sum()
+        velocities = sigmas * random.normal(0, 1, (Ntotal, 3))
+
+        total_mass = masses.sum()
+        vcm = np.sum(masses[:Natoms, None] * velocities[:Natoms], axis=0) / total_mass
         velocities[:Natoms] -= vcm
-        for i in range(Natoms, Ntotal):
+        num_constraints = system.getNumConstraints()
+        two_ke = np.sum(masses[:Natoms] * np.sum(velocities[:Natoms] ** 2, axis=1))
+        target_two_ke = (3 * Natoms - num_constraints) * kboltz * temperature
+        velocities[:Natoms] *= np.sqrt(target_two_ke / two_ke)
+
+        for i, v in enumerate(self.variables, start=Natoms):
+            two_ke = masses[i] * velocities[i][0] ** 2
+            target_two_ke = kboltz * v.temperature
+            velocities[i][0] *= np.sqrt(target_two_ke / two_ke)
             velocities[i][1:] = 0
+
         super().setVelocities(velocities)
 
 


### PR DESCRIPTION
## Description

When setting velocities from temperature, remove the COM component from the physical velocities and set vy=vz=0 for extra particles.

Optionally split velocities (like done for positions) when rettrieving from a State object.